### PR TITLE
catch PortAudioError

### DIFF
--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -178,7 +178,12 @@ class Audio_Playback(System_Plugin_Base):
 
             logger.warning("Audio found, but playback failed (#2103)")
             logger.debug(traceback.format_exc())
+        except sd.PortAudioError:
+            self.sd_stream = None
+            import traceback
 
+            logger.warning("Audio device could not be started")
+            logger.debug(traceback.format_exc())
     def _setup_audio_vis(self):
         self.audio_timeline = None
         self.audio_viz_trans = Audio_Viz_Transform(

--- a/pupil_src/shared_modules/audio_playback.py
+++ b/pupil_src/shared_modules/audio_playback.py
@@ -184,6 +184,7 @@ class Audio_Playback(System_Plugin_Base):
 
             logger.warning("Audio device could not be started")
             logger.debug(traceback.format_exc())
+            
     def _setup_audio_vis(self):
         self.audio_timeline = None
         self.audio_viz_trans = Audio_Viz_Transform(


### PR DESCRIPTION
Hi,

I had a problem running Neon Player on a Windows server machine where no sound card was installed, see https://discord.com/channels/285728493612957698/1047111711230009405/1246075184994320384. This PR fixes the application crashing when no sound device is installed. It works for me now when I am running from source.